### PR TITLE
FIX error when starting from a fresh env

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,10 +49,9 @@ if [ "$CHARTMUSEUM_APPVERSION" ]; then
 fi
 
 cd ${CHART_FOLDER}
-helm repo add https://charts.helm.sh/stable
+helm repo add stable https://charts.helm.sh/stable
 helm repo update
 helm lint .
 helm package . ${CHARTMUSEUM_APPVERSION} ${CHARTMUSEUM_VERSION}
 helm inspect chart *.tgz
 helm push *.tgz ${CHARTMUSEUM_URL} ${CHARTMUSEUM_USERNAME} ${CHARTMUSEUM_PASSWORD} ${CHARTMUSEUM_ACCESS_TOKEN} ${FORCE}
-  

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,6 +49,8 @@ if [ "$CHARTMUSEUM_APPVERSION" ]; then
 fi
 
 cd ${CHART_FOLDER}
+helm repo add https://charts.helm.sh/stable
+helm repo update
 helm lint .
 helm package . ${CHARTMUSEUM_APPVERSION} ${CHARTMUSEUM_VERSION}
 helm inspect chart *.tgz


### PR DESCRIPTION
without that go the following error with my use case:

```
Error: couldn't load repositories file (/github/home/.config/helm/repositories.yaml): open /github/home/.config/helm/repositories.yaml: no such file or directory
Error: plugin "push" exited with error
```

i guess creating the directory and an empty file shoukd be enough but anyway having the helm stable repo is still valuable and d'ont take much time