### PR TITLE
Fix generation of repo url for longer urls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN set -ex \
     && mv linux-amd64/helm /usr/local/bin/helm \
     && rm -rf linux-amd64 
 RUN apk add --virtual .helm-build-deps git make \
-    && helm plugin install https://github.com/chartmuseum/helm-push.git --version v0.14.0 \
+    && helm plugin install https://github.com/chartmuseum/helm-push.git --version v0.10.2 \
     && apk del --purge .helm-build-deps
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,6 @@ RUN apk add curl tar bash --no-cache
 RUN set -ex \
     && curl -sSL https://get.helm.sh/helm-v3.8.2-linux-amd64.tar.gz | tar xz \
     && mv linux-amd64/helm /usr/local/bin/helm \
-    && rm -rf linux-amd64 
-RUN apk add --virtual .helm-build-deps git make \
-    && helm plugin install https://github.com/chartmuseum/helm-push.git --version v0.10.2 \
-    && apk del --purge .helm-build-deps
+    && rm -rf linux-amd64
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ ENV XDG_CACHE_HOME=/opt/xdg
 
 RUN apk add curl tar bash --no-cache
 RUN set -ex \
-    && curl -sSL https://get.helm.sh/helm-v3.3.1-linux-amd64.tar.gz | tar xz \
+    && curl -sSL https://get.helm.sh/helm-v3.8.2-linux-amd64.tar.gz | tar xz \
     && mv linux-amd64/helm /usr/local/bin/helm \
     && rm -rf linux-amd64 
 RUN apk add --virtual .helm-build-deps git make \
-    && helm plugin install https://github.com/chartmuseum/helm-push.git --version v0.9.0 \
+    && helm plugin install https://github.com/chartmuseum/helm-push.git --version v0.14.0 \
     && apk del --purge .helm-build-deps
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ steps:
       chart-folder: chart
 ```
 
+Using Token Auth with OCI Registry:
+```yaml
+steps:
+  - name: Push Helm chart to OCI compatible registry (Github)
+    uses: bsord/helm-push@v4
+    with:
+      useOCIRegistry: true
+      registry-url:  https://ghcr.io/${{ github.repository }}
+      username: bsord
+      access-token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}
+      force: true
+      chart-folder: chart
+```
+
 Using Password Auth:
 ```yaml
 steps:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Using Token Auth with OCI Registry:
 ```yaml
 steps:
   - name: Push Helm chart to OCI compatible registry (Github)
-    uses: bsord/helm-push@v4
+    uses: oodlefinance/helm-push@5.0.0
     with:
       useOCIRegistry: true
       registry-url:  https://ghcr.io/${{ github.repository }}
@@ -21,17 +21,22 @@ steps:
       chart-folder: chart
 ```
 
-Using Token Auth with OCI Registry:
+Using Token Auth with AWS ECR: (Feel free to use any AWS CLI action step of your choice)
 ```yaml
 steps:
-  - name: Push Helm chart to OCI compatible registry (Github)
-    uses: bsord/helm-push@v4
+  - name: AWS ECR Login
+    id: ecr_login
+    uses: KaMeHb-UA/aws-cli-action@v3
+    with:
+      command: aws ecr get-login-password
+
+  - name: Push Helm chart to Amazon Elastic Container Registry (ECR)
+    uses: oodlefinance/helm-push@5.0.0
     with:
       useOCIRegistry: true
-      registry-url:  https://ghcr.io/${{ github.repository }}
-      username: bsord
-      access-token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}
-      force: true
+      registry-url: oci://123456789123.dkr.ecr.eu-west-1.amazonaws.com
+      username: AWS
+      access-token: ${{ steps.ecr_login.outputs.result }}
       chart-folder: chart
 ```
 
@@ -39,7 +44,7 @@ Using Password Auth:
 ```yaml
 steps:
   - name: Push Helm Chart to ChartMuseum
-    uses: bsord/helm-push@v4
+    uses: oodlefinance/helm-push@5.0.0
     with:
       username: ${{ secrets.HELM_USERNAME }}
       password: ${{ secrets.HELM_PASSWORD }}
@@ -52,7 +57,7 @@ Using Token Auth:
 ```yaml
 steps:
   - name: Push Helm Chart to ChartMuseum
-    uses: bsord/helm-push@v4
+    uses: oodlefinance/helm-push@5.0.0
     with:
       access-token: ${{ secrets.HELM_API_KEY }}
       registry-url: 'https://h.cfcr.io/user_or_org/reponame'

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Helm Push
-![Build](https://github.com/bsord/helm-push/workflows/Build/badge.svg)
-![GitHub last commit](https://img.shields.io/github/last-commit/bsord/helm-push.svg)
-![License](https://img.shields.io/github/license/bsord/helm-push.svg?style=flat)
-![PRs Welcome](https://img.shields.io/badge/PRs-welcome-green.svg)
+![Build](https://github.com/oodlefinance/helm-push/workflows/Build/badge.svg)
+![GitHub last commit](https://img.shields.io/github/last-commit/oodlefinance/helm-push.svg)
+![License](https://img.shields.io/github/license/oodlefinance/helm-push.svg?style=flat)
 
 Push a chart to a ChartMuseum or OCI compatible registry with Helm v3
 

--- a/action.yml
+++ b/action.yml
@@ -22,9 +22,9 @@ inputs:
     required: true
     default: ''
   chart-folder:
-      description: 'Relative path to chart folder'
-      required: false
-      default: 'chart'
+    description: 'Relative path to chart folder'
+    required: false
+    default: 'chart'
   version:
     description: 'Chart Version'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,10 +29,13 @@ if [ "$USE_OCI_REGISTRY" == "TRUE" ] || [ "$USE_OCI_REGISTRY" == "true" ]; then
   echo "OCI SPECIFIED, USING HELM OCI FEATURES"
   REGISTRY=$(echo "${REGISTRY_URL}" | awk -F[/:] '{print $4}') # Get registry host from url
   echo "${REGISTRY_ACCESS_TOKEN}" | helm registry login -u ${REGISTRY_USERNAME} --password-stdin ${REGISTRY} # Authenticate registry
-  REGISTRY_URL=$(echo "${REGISTRY_URL#*//}")
-  VERSION=$(helm chart save ${CHART_FOLDER} ${REGISTRY_URL} | grep 'saved' | cut -d':' -f1) # Save the chart, and extract version
-  FULLPACKAGEREF="${REGISTRY_URL}:${VERSION}"
-  helm chart push ${FULLPACKAGEREF} # Push chart to registry
+  echo "Packaging chart '$CHART_NAME'"
+  PKG_RESPONSE=$(helm package $CHART_NAME) # package chart
+  echo "$PKG_RESPONSE"
+  CHART_TAR_GZ=$(basename "$PKG_RESPONSE") # extract tar name from helm package stdout
+  echo "Pushing chart $CHART_TAR_GZ to 'oci://$REGISTRY'"
+  helm push "$CHART_TAR_GZ" "oci://$REGISTRY"
+  echo "Successfully pushed chart $CHART_TAR_GZ to 'oci://$REGISTRY'"
   exit 0
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,12 +30,12 @@ if [ "$USE_OCI_REGISTRY" == "TRUE" ] || [ "$USE_OCI_REGISTRY" == "true" ]; then
   REGISTRY=$(echo "${REGISTRY_URL}" | awk -F[/:] '{print $4}') # Get registry host from url
   echo "${REGISTRY_ACCESS_TOKEN}" | helm registry login -u ${REGISTRY_USERNAME} --password-stdin ${REGISTRY} # Authenticate registry
   echo "Packaging chart '$CHART_NAME'"
-  PKG_RESPONSE=$(helm package $CHART_NAME) # package chart
-  echo "$PKG_RESPONSE"
-  CHART_TAR_GZ=$(basename "$PKG_RESPONSE") # extract tar name from helm package stdout
-  echo "Pushing chart $CHART_TAR_GZ to 'oci://$REGISTRY'"
-  helm push "$CHART_TAR_GZ" "oci://$REGISTRY"
-  echo "Successfully pushed chart $CHART_TAR_GZ to 'oci://$REGISTRY'"
+#  PKG_RESPONSE=$(helm package $CHART_NAME) # package chart
+#  echo "$PKG_RESPONSE"
+#  CHART_TAR_GZ=$(basename "$PKG_RESPONSE") # extract tar name from helm package stdout
+#  echo "Pushing chart $CHART_TAR_GZ to 'oci://$REGISTRY'"
+#  helm push "$CHART_TAR_GZ" "oci://$REGISTRY"
+#  echo "Successfully pushed chart $CHART_TAR_GZ to 'oci://$REGISTRY'"
   exit 0
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,9 +29,9 @@ if [ "$USE_OCI_REGISTRY" == "TRUE" ] || [ "$USE_OCI_REGISTRY" == "true" ]; then
   echo "OCI SPECIFIED, USING HELM OCI FEATURES"
   REGISTRY=$(echo "${REGISTRY_URL}" | awk -F[/:] '{print $4}') # Get registry host from url
   echo "${REGISTRY_ACCESS_TOKEN}" | helm registry login -u ${REGISTRY_USERNAME} --password-stdin ${REGISTRY} # Authenticate registry
-  echo "Packaging chart '$CHART_NAME'"
-#  PKG_RESPONSE=$(helm package $CHART_NAME) # package chart
-#  echo "$PKG_RESPONSE"
+  echo "Packaging chart '$CHART_FOLDER'"
+  PKG_RESPONSE=$(helm package $CHART_FOLDER) # package chart
+  echo "$PKG_RESPONSE"
 #  CHART_TAR_GZ=$(basename "$PKG_RESPONSE") # extract tar name from helm package stdout
 #  echo "Pushing chart $CHART_TAR_GZ to 'oci://$REGISTRY'"
 #  helm push "$CHART_TAR_GZ" "oci://$REGISTRY"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,8 +30,8 @@ if [ "$USE_OCI_REGISTRY" == "TRUE" ] || [ "$USE_OCI_REGISTRY" == "true" ]; then
   REGISTRY=$(echo "${REGISTRY_URL}" | awk -F[/:] '{print $4}') # Get registry host from url
   echo "${REGISTRY_ACCESS_TOKEN}" | helm registry login -u ${REGISTRY_USERNAME} --password-stdin ${REGISTRY} # Authenticate registry
   REGISTRY_URL=$(echo "${REGISTRY_URL#*//}")
-  helm chart save ${CHART_FOLDER} ${REGISTRY_URL} # Save the chart, using tag from the chart
-  FULLPACKAGEREF=$(helm chart list | sed '2q;d' | cut -d' ' -f1) # Get full package reference from newly saved chart
+  VERSION=$(helm chart save ${CHART_FOLDER} ${REGISTRY_URL} | grep 'saved' | cut -d':' -f1) # Save the chart, and extract version
+  FULLPACKAGEREF="${REGISTRY_URL}:${VERSION}"
   helm chart push ${FULLPACKAGEREF} # Push chart to registry
   exit 0
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,9 +33,9 @@ if [ "$USE_OCI_REGISTRY" == "TRUE" ] || [ "$USE_OCI_REGISTRY" == "true" ]; then
   PKG_RESPONSE=$(helm package $CHART_FOLDER) # package chart
   echo "$PKG_RESPONSE"
   CHART_TAR_GZ=$(basename "$PKG_RESPONSE") # extract tar name from helm package stdout
-  echo "Pushing chart $CHART_TAR_GZ to 'oci://$REGISTRY'"
-  helm push "$CHART_TAR_GZ" "oci://$REGISTRY"
-  echo "Successfully pushed chart $CHART_TAR_GZ to 'oci://$REGISTRY'"
+  echo "Pushing chart $CHART_TAR_GZ to '$REGISTRY_URL'"
+  helm push "$CHART_TAR_GZ" "$REGISTRY_URL"
+  echo "Successfully pushed chart $CHART_TAR_GZ to '$REGISTRY_URL'"
   exit 0
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,10 +32,10 @@ if [ "$USE_OCI_REGISTRY" == "TRUE" ] || [ "$USE_OCI_REGISTRY" == "true" ]; then
   echo "Packaging chart '$CHART_FOLDER'"
   PKG_RESPONSE=$(helm package $CHART_FOLDER) # package chart
   echo "$PKG_RESPONSE"
-#  CHART_TAR_GZ=$(basename "$PKG_RESPONSE") # extract tar name from helm package stdout
-#  echo "Pushing chart $CHART_TAR_GZ to 'oci://$REGISTRY'"
-#  helm push "$CHART_TAR_GZ" "oci://$REGISTRY"
-#  echo "Successfully pushed chart $CHART_TAR_GZ to 'oci://$REGISTRY'"
+  CHART_TAR_GZ=$(basename "$PKG_RESPONSE") # extract tar name from helm package stdout
+  echo "Pushing chart $CHART_TAR_GZ to 'oci://$REGISTRY'"
+  helm push "$CHART_TAR_GZ" "oci://$REGISTRY"
+  echo "Successfully pushed chart $CHART_TAR_GZ to 'oci://$REGISTRY'"
   exit 0
 fi
 


### PR DESCRIPTION
This PR fixes the issue reported in https://github.com/bsord/helm-push/issues/16

It will instead grab the version it needs for `helm chart publish`  from the output of `helm chart save`, and build the required URL for the OCI registry from that.

We've tested this with our own workflow and it now works. Feel free to use our fix, or do it in a cleaner way. 

Thanks :) 