### PR TITLE
feat: support for dependencies build pre-packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ steps:
 | `registry-url` | Registry url | **Yes** | "" |
 | `chart-folder` | Relative path to chart folder to be published| No | chart |
 | `force` | Force overwrite if version already exists | No | false |
+| `update-dependencies` | Update dependencies from "Chart.yaml" to dir "charts/" before packaging | No | false |
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: 'Whether or not to override existing chart with same version'
     required: false
     default: 'false'
+  update-dependencies:
+    description: "Whether or not to update dependencies before packaging"
+    required: false
+    default: "false"
   useOCIRegistry:
     description: 'If publishing to big cloud registries, utilizing OCI container spec for helm packages, set to true'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,13 +24,19 @@ else
   FORCE=""
 fi
 
+if [ "$UPDATE_DEPENDENCIES" == "1" ] || [ "$UPDATE_DEPENDENCIES" == "True" ] || [ "$UPDATE_DEPENDENCIES" == "TRUE" ] || [ "$UPDATE_DEPENDENCIES" == "true" ]; then
+  UPDATE_DEPENDENCIES="-u"
+else
+  UPDATE_DEPENDENCIES=""
+fi
+
 if [ "$USE_OCI_REGISTRY" == "TRUE" ] || [ "$USE_OCI_REGISTRY" == "true" ]; then
   export HELM_EXPERIMENTAL_OCI=1
   echo "OCI SPECIFIED, USING HELM OCI FEATURES"
   REGISTRY=$(echo "${REGISTRY_URL}" | awk -F[/:] '{print $4}') # Get registry host from url
   echo "${REGISTRY_ACCESS_TOKEN}" | helm registry login -u ${REGISTRY_USERNAME} --password-stdin ${REGISTRY} # Authenticate registry
   echo "Packaging chart '$CHART_FOLDER'"
-  PKG_RESPONSE=$(helm package $CHART_FOLDER) # package chart
+  PKG_RESPONSE=$(helm package $CHART_FOLDER $UPDATE_DEPENDENCIES) # package chart
   echo "$PKG_RESPONSE"
   CHART_TAR_GZ=$(basename "$PKG_RESPONSE") # extract tar name from helm package stdout
   echo "Pushing chart $CHART_TAR_GZ to '$REGISTRY_URL'"
@@ -71,6 +77,6 @@ cd ${CHART_FOLDER}
 helm repo add stable https://charts.helm.sh/stable
 helm repo update
 helm lint .
-helm package . ${REGISTRY_APPVERSION} ${REGISTRY_VERSION}
+helm package . ${REGISTRY_APPVERSION} ${REGISTRY_VERSION} ${UPDATE_DEPENDENCIES}
 helm inspect chart *.tgz
 helm cm-push *.tgz ${REGISTRY_URL} ${REGISTRY_USERNAME} ${REGISTRY_PASSWORD} ${REGISTRY_ACCESS_TOKEN} ${FORCE}


### PR DESCRIPTION
This PR aims to allow charts to be handled when they have dependencies not built before being processed by this action. It creates an option `update-dependencies` that injects the flag `-u`  while executing the command `helm package`.

Closes #21