### PR TITLE
feat: helm add repositories from list

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,16 +66,17 @@ steps:
 
 ### Parameters
 
-| Key | Value | Required | Default |
-| ------------- | ------------- | ------------- | ------------- |
-| `useOCIRegistry` | Push to OCI compatibly registry | No | false |
-| `access-token` | API Token with Helm read/write permissions | **Yes** (if using token auth) | "" |
-| `username` | Username for registry | **Yes** (if using pw auth) | "" |
-| `password` | Password for registry | **Yes** (if using pw auth) | "" |
-| `registry-url` | Registry url | **Yes** | "" |
-| `chart-folder` | Relative path to chart folder to be published| No | chart |
-| `force` | Force overwrite if version already exists | No | false |
-| `update-dependencies` | Update dependencies from "Chart.yaml" to dir "charts/" before packaging | No | false |
+| Key | Value                                                                                       | Required | Default |
+| ------------- |---------------------------------------------------------------------------------------------| ------------- | ------------- |
+| `useOCIRegistry` | Push to OCI compatibly registry                                                             | No | false |
+| `access-token` | API Token with Helm read/write permissions                                                  | **Yes** (if using token auth) | "" |
+| `username` | Username for registry                                                                       | **Yes** (if using pw auth) | "" |
+| `password` | Password for registry                                                                       | **Yes** (if using pw auth) | "" |
+| `registry-url` | Registry url                                                                                | **Yes** | "" |
+| `chart-folder` | Relative path to chart folder to be published                                               | No | chart |
+| `force` | Force overwrite if version already exists                                                   | No | false |
+| `update-dependencies` | Update dependencies from "Chart.yaml" to dir "charts/" before packaging                     | No | false |
+| `add-repositories` | Optionally add list of Helm Repositories to add running `helm repo add $args` for each line | No | "" |
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 # action.yml
 name: 'Helm Push'
-description: 'Pushes a local chart to a ChartMusem or OCI compatible registry. Supports token based auth and Chart.yaml version override.'
+description: 'Pushes a local chart to a ChartMuseum or OCI compatible registry. Supports token based auth and Chart.yaml version override.'
 branding:
   color: 'green'
   icon: 'upload-cloud'
@@ -45,6 +45,15 @@ inputs:
     description: 'If publishing to big cloud registries, utilizing OCI container spec for helm packages, set to true'
     required: false
     default: 'false'
+  add-repositories:
+    description: 'Optionally add list of Helm Repositories to add running `helm repo add $args`'
+    required: false
+    # valid list of args for `helm repo add $args` each line maps to repo add e.g.
+    # add-repositories: |
+    #     stable https://charts.helm.sh/stable
+    #     private https//private.internal --username private --password 'bulls eye'
+    #     ...
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -58,3 +67,5 @@ runs:
     REGISTRY_VERSION: ${{ inputs.version }}
     REGISTRY_APPVERSION: ${{ inputs.appVersion }}
     USE_OCI_REGISTRY: ${{ inputs.useOCIRegistry }}
+    UPDATE_DEPENDENCIES: ${{ inputs.update-dependencies }}
+    ADD_REPOSITORIES: ${{ inputs.add-repositories }}

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ inputs:
     required: false
     default: 'false'
   add-repositories:
-    description: 'Optionally add list of Helm Repositories to add running `helm repo add $args`'
+    description: 'Optionally add list of Helm Repositories to add running `helm repo add $args` for each line'
     required: false
     # valid list of args for `helm repo add $args` each line maps to repo add e.g.
     # add-repositories: |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,11 +71,15 @@ if [ "$REGISTRY_APPVERSION" ]; then
   REGISTRY_APPVERSION="--app-version ${REGISTRY_APPVERSION}"
 fi
 
-
+if [ "$ADD_REPOSITORIES" != "" ]; then
+  while read addRepositoryArgs;
+  do
+    eval $(echo helm repo add $addRepositoryArgs)
+  done <<< "$ADD_REPOSITORIES"
+  helm repo update
+fi
 
 cd ${CHART_FOLDER}
-helm repo add stable https://charts.helm.sh/stable
-helm repo update
 helm lint .
 helm package . ${REGISTRY_APPVERSION} ${REGISTRY_VERSION} ${UPDATE_DEPENDENCIES}
 helm inspect chart *.tgz


### PR DESCRIPTION
Testing with:
```
docker build . -t smoke/helm-push && \
docker run --rm -it -v $(pwd)/../../cloud:/cloud \
-e REGISTRY_USERNAME="user" \
-e REGISTRY_PASSWORD="pass" \
-e REGISTRY_URL="http://example.com/charts" \
-e CHART_FOLDER="/cloud/charts" \
-e "ADD_REPOSITORIES=$(echo -e stable https://charts.helm.sh/stable\\nprivate https//private.internal --username private --password \'bulls eye\')"\
smoke/helm-push
```

will issue the following commands:
```
helm repo add stable https://charts.helm.sh/stable
helm repo add private https//private.internal --username private --password 'bulls eye'
helm repo update
```