### PR TITLE
Allow overriding version/appversion on when oci registry is enabled

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,10 +24,20 @@ else
   FORCE=""
 fi
 
-if [ "$UPDATE_DEPENDENCIES" == "1" ] || [ "$UPDATE_DEPENDENCIES" == "True" ] || [ "$UPDATE_DEPENDENCIES" == "TRUE" ] || [ "$UPDATE_DEPENDENCIES" == "true" ]; then
+if [ "$UPDATE_DEPENDENCIES" == "1" ] || [[ "$UPDATE_DEPENDENCIES" == [Tt][Rr][Uu][Ee] ]]; then
   UPDATE_DEPENDENCIES="-u"
 else
   UPDATE_DEPENDENCIES=""
+fi
+
+if [ "$REGISTRY_VERSION" ]; then
+  echo "Version is defined, using as parameter."
+  REGISTRY_VERSION="--version ${REGISTRY_VERSION}"
+fi
+
+if [ "$REGISTRY_APPVERSION" ]; then
+  echo "App version is defined, using as parameter."
+  REGISTRY_APPVERSION="--app-version ${REGISTRY_APPVERSION}"
 fi
 
 if [ "$USE_OCI_REGISTRY" == "TRUE" ] || [ "$USE_OCI_REGISTRY" == "true" ]; then
@@ -36,7 +46,7 @@ if [ "$USE_OCI_REGISTRY" == "TRUE" ] || [ "$USE_OCI_REGISTRY" == "true" ]; then
   REGISTRY=$(echo "${REGISTRY_URL}" | awk -F[/:] '{print $4}') # Get registry host from url
   echo "${REGISTRY_ACCESS_TOKEN}" | helm registry login -u ${REGISTRY_USERNAME} --password-stdin ${REGISTRY} # Authenticate registry
   echo "Packaging chart '$CHART_FOLDER'"
-  PKG_RESPONSE=$(helm package $CHART_FOLDER $UPDATE_DEPENDENCIES) # package chart
+  PKG_RESPONSE=$(helm package ${CHART_FOLDER} ${REGISTRY_VERSION} ${REGISTRY_APPVERSION} ${UPDATE_DEPENDENCIES}) # package chart
   echo "$PKG_RESPONSE"
   CHART_TAR_GZ=$(basename "$PKG_RESPONSE") # extract tar name from helm package stdout
   echo "Pushing chart $CHART_TAR_GZ to '$REGISTRY_URL'"
@@ -59,16 +69,6 @@ fi
 if [ "$REGISTRY_PASSWORD" ]; then
   echo "Password is defined, using as parameter."
   REGISTRY_PASSWORD="--password ${REGISTRY_PASSWORD}"
-fi
-
-if [ "$REGISTRY_VERSION" ]; then
-  echo "Version is defined, using as parameter."
-  REGISTRY_VERSION="--version ${REGISTRY_VERSION}"
-fi
-
-if [ "$REGISTRY_APPVERSION" ]; then
-  echo "App version is defined, using as parameter."
-  REGISTRY_APPVERSION="--app-version ${REGISTRY_APPVERSION}"
 fi
 
 if [ "$ADD_REPOSITORIES" != "" ]; then


### PR DESCRIPTION
When enabling the OCI registry, it is not possible to override Helm chart's version and appversion. With this change it is made possible.