### PR TITLE
Support port number in registry_url parameter

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,7 +33,7 @@ fi
 if [ "$USE_OCI_REGISTRY" == "TRUE" ] || [ "$USE_OCI_REGISTRY" == "true" ]; then
   export HELM_EXPERIMENTAL_OCI=1
   echo "OCI SPECIFIED, USING HELM OCI FEATURES"
-  REGISTRY=$(echo "${REGISTRY_URL}" | awk -F[/:] '{print $4}') # Get registry host from url
+  REGISTRY=$(echo "${REGISTRY_URL}" | awk -F[/] '{print $3}') # Get registry host from url
   echo "${REGISTRY_ACCESS_TOKEN}" | helm registry login -u ${REGISTRY_USERNAME} --password-stdin ${REGISTRY} # Authenticate registry
   echo "Packaging chart '$CHART_FOLDER'"
   PKG_RESPONSE=$(helm package $CHART_FOLDER $UPDATE_DEPENDENCIES) # package chart

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,7 +33,7 @@ fi
 if [ "$USE_OCI_REGISTRY" == "TRUE" ] || [ "$USE_OCI_REGISTRY" == "true" ]; then
   export HELM_EXPERIMENTAL_OCI=1
   echo "OCI SPECIFIED, USING HELM OCI FEATURES"
-  REGISTRY=$(echo "${REGISTRY_URL}" | awk -F[/] '{print $3}') # Get registry host from url
+  REGISTRY=$(echo "${REGISTRY_URL}" | awk -F[/] '{print $3}') # Get registry host and port from url
   echo "${REGISTRY_ACCESS_TOKEN}" | helm registry login -u ${REGISTRY_USERNAME} --password-stdin ${REGISTRY} # Authenticate registry
   echo "Packaging chart '$CHART_FOLDER'"
   PKG_RESPONSE=$(helm package $CHART_FOLDER $UPDATE_DEPENDENCIES) # package chart


### PR DESCRIPTION
If registry_url has port number given, the current implementation cuts it out for the `helm registry login` command, causing it to try logging in with default port 443 and failing.